### PR TITLE
adjust import method and path to form ts for v9

### DIFF
--- a/Configuration/TypoScript/form/form.typoscript
+++ b/Configuration/TypoScript/form/form.typoscript
@@ -1,4 +1,5 @@
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:form/Configuration/TypoScript/setup.txt">
+@import 'EXT:form/Configuration/TypoScript/setup.typoscript'
+
 plugin.tx_form {
   settings {
     yamlConfigurations {


### PR DESCRIPTION
This fixes the following error:

`Sorry, the requested view was not found.

The technical reason is: No template was found. View could not be resolved for action "render" in class "TYPO3\CMS\Form\Controller\FormFrontendController".`