### PR TITLE
[TASK] always copy static images in Images/Misc/ on watch

### DIFF
--- a/Resources/Build/webpack.common.js
+++ b/Resources/Build/webpack.common.js
@@ -128,9 +128,10 @@ module.exports = {
         new UglifyJsPlugin({
             extractComments: true
         }),
-        new CopyPlugin([
-            {from: 'Assets/Images/Misc', to: 'Images/Misc'}
-        ]),
+        new CopyPlugin(
+            [{from: 'Assets/Images/Misc', to: 'Images/Misc'}],
+            { copyUnmodified: true }
+        ),
         new CopyPlugin([
             {from: 'Assets/JavaScripts/static', to: 'JavaScripts'},
             {from: 'Assets/CKEditor', to: 'CKEditor'}


### PR DESCRIPTION
The watcher does not copy files used in the layout, that are static, because it does not watch the Folders/Files containing these Images. This commit makes the watch task copy the files correctly.